### PR TITLE
fix: linux deb package name compatibility

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "icones",
+  "productName": "Icônes",
   "version": "0.1.1",
   "identifier": "studio.deserve.icones",
   "build": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Icônes",
+  "productName": "icones",
   "version": "0.1.1",
   "identifier": "studio.deserve.icones",
   "build": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,3 @@
+{
+  "productName": "icones"
+}


### PR DESCRIPTION
Use `tauri.linux.conf.json` to override `productName` to lowercase `icones` only on Linux, keeping `Icônes` on macOS and Windows.\n\nDebian requires package names to contain only lowercase letters, digits, and `-+._`.